### PR TITLE
Finding the follow user bug and fix

### DIFF
--- a/Makestagram/Helpers/ParseHelper.swift
+++ b/Makestagram/Helpers/ParseHelper.swift
@@ -169,7 +169,7 @@ class ParseHelper {
     static func getFollowingUsersForUser(user: PFUser, completionBlock: PFQueryArrayResultBlock) {
         
         let query = PFQuery(className: ParseFollowClass)
-        query.whereKey(ParseFollowToUser, equalTo:user)
+        query.whereKey(ParseFollowFromUser, equalTo:user)
         query.findObjectsInBackgroundWithBlock(completionBlock)
     }
     


### PR DESCRIPTION
Logic error while following a user:
It allows to follow the same user multiple times, instead of the
proposed toggle to follow and unfollow.
Fixed: incorrect use of Key in
getFollowingUsersForUser(user:completionBlock:) in ParseHelper.

Instead of getting the following base for this user, it queried the
following base for the toUser in the Follow object, which allowed to
follow itself.
